### PR TITLE
make space between cmd_name and args able to control

### DIFF
--- a/doc/draft.saty
+++ b/doc/draft.saty
@@ -42,18 +42,18 @@ document(|
     show-title = true;
 |)'<
     +newpage;
-    +p {
+    +p{
         \SATySFi;を使うに当たって、formatter が無いのが不便だったので、format をするためのツールを作りました。
-        \footnote { このドキュメントは format のテストも兼ねて書いています。 }
-        \footnote {
+        \footnote{ このドキュメントは format のテストも兼ねて書いています。 }
+        \footnote{
             \SATySFi;の文法に習熟している訳ではないため、parserを元に復元するという手法によりフォーマットを実現おり、容易にビルドが失敗するようになります。(22/3/11 現在)
         }
     }
-    +section { formatter の install 方法 } <
-        +p {
+    +section{ formatter の install 方法 }<
+        +p{
             以下のどちらかの方法で、入れることができます。
             ターミナルに以下のコマンドを打ち込んでください。
-            \footnote {
+            \footnote{
                 --force は無くても入りますが、既にインストールしている場合、
                 最新のデータにアップデートするために同じコマンドを使用できます。
             }
@@ -64,14 +64,14 @@ cd satysfi-formatter
 cargo install --path .
 `);
     >
-    +section { formatter の使い方 } <
+    +section{ formatter の使い方 }<
         +cmd (`satysfi-fmt $input -o $output`);
-        +p {
+        +p{
             `output`を指定しなかった場合、コマンドラインの標準出力に結果が表示されます。
         }
     >
-    +section { 開発者の方 } <
-        +p {
+    +section{ 開発者の方 }<
+        +p{
             `release build`でない場合、
             `src/visualize.rs`にある関数が呼び出されるようになっており、ファイルの構造を確認できるようになってます。
             \cmd (`cargo run -- $input`);
@@ -85,16 +85,16 @@ cargo install --path .
             % comment
             Issue でいただく場合、期待するフォーマットのテストをいただけるとスムーズに対応ができると思います。 その際、実際にそれがコンパイル可能である必要はありません。
         }
-        +subsection { Pull Request } <
-            +p {
+        +subsection{ Pull Request }<
+            +p{
                 実装した部分のテストケースを書いていただいてから、プルリクエストをいただけると幸いです。
                 その際、
                 `src/tests`以下でしたら何処に書いていただいても構いません。
-                \footnote { そもそもまだ全部のテストケースが通らない…… }
+                \footnote{ そもそもまだ全部のテストケースが通らない…… }
             }
         >
-        +subsection { issue } <
-            +p {
+        +subsection{ issue }<
+            +p{
                 以下にサンプル（
                 `src/tests/common.rs` `test1`と同じ）を載せておきます。
                 `r#""`の内部に書かれたテキストはスペースや改行を含め全てそのまま出力されるため、
@@ -121,13 +121,13 @@ document(|title = {hello}|)'<
             }
         >
     >
-    +section { \SATySFi;-formatter の実装 } <
-        +subsection { indent の管理 } <
-            +p {
+    +section{ \SATySFi;-formatter の実装 }<
+        +subsection{ indent の管理 }<
+            +p{
                 \SATySFi;-formatter では以下の場所でインデントの管理を行っています。
             }
-            +p { インデントが以下の場所では深くなります。 }
-            +p {
+            +p{ インデントが以下の場所では深くなります。 }
+            +p{
                 % \listing {
                 \* block_text
                 \* cmd_text_arg
@@ -145,13 +145,13 @@ document(|title = {hello}|)'<
                 \* struct_stmt
                 % }
             }
-            +p {
+            +p{
                 let-\* 文については 次の行が let-\* 文以外のとき、インデントが1つ深くなります。
             }
         >
-        +subsection { そのまま出力する場所 } <
-            +p {
-                \listing {
+        +subsection{ そのまま出力する場所 }<
+            +p{
+                \listing{
                     * 変数名
                       ** pkgname
                       ** arg
@@ -181,8 +181,8 @@ document(|title = {hello}|)'<
             }
         >
     >
-    +section { document の更新 } <
-        +p {
+    +section{ document の更新 }<
+        +p{
             `draft.saty`を更新して、以下のコマンドを叩くと
             `doc.pdf`を更新します。 \cmd (`cargo make build-doc`);
             その際、
@@ -190,8 +190,8 @@ document(|title = {hello}|)'<
             \cmd (`cargo install --force cargo-make`);
         }
     >
-    +section { format } <
-        +p {
+    +section{ format }<
+        +p{
             基本の indent は 4 です。(そのうち引数で管理ができるようにします)
         }
     >

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -777,6 +777,23 @@ impl<'a> Formatter<'a> {
                 })
                 .trim_end()
                 .to_string(),
+            Rule::block_cmd | Rule::inline_cmd => {
+                csts.iter().fold(String::new(), |current, now_cst| {
+                    let s = self.to_string_cst(text, now_cst, depth);
+                    if current.is_empty() {
+                        s
+                    } else if s.is_empty() {
+                        current
+                    } else if current.ends_with(&newline) {
+                        current + &s
+                    } else if now_cst.rule == Rule::cmd_text_arg && !self.option.command_args_space
+                    {
+                        current + &s
+                    } else {
+                        current + sep + &s
+                    }
+                })
+            }
             _ => {
                 csts.iter().fold(String::new(), |current, now_cst| {
                     let s = self.to_string_cst(text, now_cst, depth);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub use visualize::*;
 pub struct OptionData {
     pub row_length: usize,
     pub indent_space: usize,
+    pub command_args_space: bool,
 }
 
 impl Default for OptionData {
@@ -20,6 +21,7 @@ impl Default for OptionData {
         Self {
             row_length: 80,
             indent_space: 4,
+            command_args_space: true,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,12 @@ struct Cli {
     file: PathBuf,
     #[clap(short, long)]
     output: Option<PathBuf>,
+    /// indent size
     #[clap(short, long, default_value_t = 4)]
     indent_space: usize,
+     /// Add space before arguments in command
+    #[clap(long)]
+    cspace: bool
 }
 
 fn main() {
@@ -19,6 +23,7 @@ fn main() {
     let code = fs::read_to_string(&cli.file).expect("Failed to read file");
     let option = OptionData {
         indent_space: cli.indent_space,
+        command_args_space: cli.cspace,
         ..Default::default()
     };
     let output = format(&code, option);


### PR DESCRIPTION
--cspace という引数によりコマンドの引数との間、および複数引数を取る場合にはその間にスペースを入れるかどうかを管理できるように

```
# not --cspace
+p{}
```

```
# include --cspace
+p {}
```