### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+
+# The indent size used in the `package.json` file cannot be changed
+# https://github.com/npm/npm/pull/3180#issuecomment-16336516
+[**/tests/*.rs]
+trim_trailing_whitespace = false
+
+[*.{saty,satyh}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false


### PR DESCRIPTION
.editorconfig を追加して、テストコードなどの保存時に行末の空白が削除されないように