### PR TITLE
Linebreak after any let...in

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -687,20 +687,12 @@ impl<'a> Formatter<'a> {
                                 | Rule::let_mutable_stmt
                                 | Rule::open_stmt => {
                                     if index == 0 {
-                                        current + &s + " " + RESERVED_WORD.in_stmt
+                                        current + &s + " " + RESERVED_WORD.in_stmt + &newline
                                     } else {
-                                        current + &newline + &s + " " + RESERVED_WORD.in_stmt
+                                        current + &newline + &s + " " + RESERVED_WORD.in_stmt + &newline
                                     }
                                 }
                                 Rule::expr => {
-                                    let current =
-                                        if index > 0 && csts[index - 1].rule == Rule::comments {
-                                            current
-                                        } else if s.starts_with("let") || s.contains('\n') {
-                                            current + &newline
-                                        } else {
-                                            current + " "
-                                        };
                                     if s.starts_with("let") {
                                         current + s.trim_start()
                                     } else if s.contains('\n') {

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -283,3 +283,25 @@ document(|title = {}|)'<
 "#;
     test_tmpl(text, expect);
 }
+
+#[test]
+fn test14() {
+    let text = r#"let f x = z"#;
+    let expect = r#"let f x = z
+"#;
+    test_tmpl(text, expect);
+}
+
+#[test]
+fn test15() {
+    let text = r#"let f x =
+let y = x in
+let z = y in
+ z"#;
+    let expect = r#"let f x =
+    let y = x in
+    let z = y in
+    z
+"#;
+    test_tmpl(text, expect);
+}

--- a/src/tests/ctrl_stmt.rs
+++ b/src/tests/ctrl_stmt.rs
@@ -85,7 +85,8 @@ document(|title = {hello}|)'<
 let-mutable x <- 0
 let () = while (!x < 2) do x <- !x + 1
 let-inline \inline =
-    let text = embed-string (arabic !x) in { #text; }
+    let text = embed-string (arabic !x) in
+    { #text; }
 in
 
 document(|title = { hello }|)'<

--- a/src/tests/module.rs
+++ b/src/tests/module.rs
@@ -61,10 +61,12 @@ end = struct
                 c = (fun it -> nc (inline-fil ++ read-inline ctx it ++ inline-fil));
                 m = (fun i j it -> mc i j (inline-fil ++ read-inline ctx it ++ inline-fil));
                 e = EmptyCell;
-            |) in tabular cellss decof
+            |) in
+        tabular cellss decof
 
     let-inline ctx \tabular =
-        let pads = (2pt, 2pt, 2pt, 2pt) in table-scheme ctx pads
+        let pads = (2pt, 2pt, 2pt, 2pt) in
+        table-scheme ctx pads
 end
 "#;
     test_tmpl(&input, expect)


### PR DESCRIPTION
This is just a design choice, but I believe this behavior is closer to ocamlformat.