### PR TITLE
update cache to v4

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
@@ -23,7 +23,7 @@ jobs:
           target
           ~/satysfi
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: clone satysfi-package
       run: |
         if [ ! -d ~/satysfi ]; then

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -305,3 +305,21 @@ let z = y in
 "#;
     test_tmpl(text, expect);
 }
+
+#[test]
+fn test16() {
+    let text = r#"let f x =
+let y = x in
+let z = y in
+ z
+
+let a = 1
+let b = 2
+"#;
+    let expect = r#"let f x =
+    let y = x in
+    let z = y in
+    z
+"#;
+    test_tmpl(text, expect);
+}

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -305,21 +305,3 @@ let z = y in
 "#;
     test_tmpl(text, expect);
 }
-
-#[test]
-fn test16() {
-    let text = r#"let f x =
-let y = x in
-let z = y in
- z
-
-let a = 1
-let b = 2
-"#;
-    let expect = r#"let f x =
-    let y = x in
-    let z = y in
-    z
-"#;
-    test_tmpl(text, expect);
-}


### PR DESCRIPTION
GitHub workflow ライブラリを更新します

cache v2 が deprecated で動作しなくなってしまったため、v4 に上げます